### PR TITLE
Add new role support. This enables designated users to see all jobs.

### DIFF
--- a/cmd/cc-backend/main.go
+++ b/cmd/cc-backend/main.go
@@ -142,7 +142,7 @@ func main() {
 	flag.BoolVar(&flagStopImmediately, "no-server", false, "Do not start a server, stop right after initialization and argument handling")
 	flag.BoolVar(&flagGops, "gops", false, "Listen via github.com/google/gops/agent (for debugging)")
 	flag.StringVar(&flagConfigFile, "config", "./config.json", "Overwrite the global config options by those specified in `config.json`")
-	flag.StringVar(&flagNewUser, "add-user", "", "Add a new user. Argument format: `<username>:[admin,api,user]:<password>`")
+	flag.StringVar(&flagNewUser, "add-user", "", "Add a new user. Argument format: `<username>:[admin,support,api,user]:<password>`")
 	flag.StringVar(&flagDelUser, "del-user", "", "Remove user by `username`")
 	flag.StringVar(&flagGenJWT, "jwt", "", "Generate and print a JWT for the user specified by its `username`")
 	flag.StringVar(&flagImportJob, "import-job", "", "Import a job. Argument format: `<path-to-meta.json>:<path-to-data.json>,...`")

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -19,9 +19,10 @@ import (
 )
 
 const (
-	RoleAdmin string = "admin"
-	RoleApi   string = "api"
-	RoleUser  string = "user"
+	RoleAdmin   string = "admin"
+	RoleSupport string = "support"
+	RoleApi     string = "api"
+	RoleUser    string = "user"
 )
 
 const (

--- a/internal/auth/users.go
+++ b/internal/auth/users.go
@@ -112,7 +112,7 @@ func (auth *Authentication) AddRole(ctx context.Context, username string, role s
 		return err
 	}
 
-	if role != RoleAdmin && role != RoleApi && role != RoleUser {
+	if role != RoleAdmin && role != RoleApi && role != RoleUser && role != RoleSupport {
 		return fmt.Errorf("invalid user role: %#v", role)
 	}
 
@@ -131,7 +131,7 @@ func (auth *Authentication) AddRole(ctx context.Context, username string, role s
 
 func FetchUser(ctx context.Context, db *sqlx.DB, username string) (*model.User, error) {
 	me := GetUser(ctx)
-	if me != nil && !me.HasRole(RoleAdmin) && me.Username != username {
+	if me != nil && !me.HasRole(RoleAdmin) && !me.HasRole(RoleSupport) && me.Username != username {
 		return nil, errors.New("forbidden")
 	}
 

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -142,7 +142,7 @@ func (r *queryResolver) Job(ctx context.Context, id string) (*schema.Job, error)
 		return nil, err
 	}
 
-	if user := auth.GetUser(ctx); user != nil && !user.HasRole(auth.RoleAdmin) && job.User != user.Username {
+	if user := auth.GetUser(ctx); user != nil && !user.HasRole(auth.RoleAdmin) && !user.HasRole(auth.RoleSupport) && job.User != user.Username {
 		return nil, errors.New("you are not allowed to see this job")
 	}
 

--- a/internal/repository/job.go
+++ b/internal/repository/job.go
@@ -309,7 +309,7 @@ func (r *JobRepository) FindJobOrUser(ctx context.Context, searchterm string) (j
 	user := auth.GetUser(ctx)
 	if id, err := strconv.Atoi(searchterm); err == nil {
 		qb := sq.Select("job.id").From("job").Where("job.job_id = ?", id)
-		if user != nil && !user.HasRole(auth.RoleAdmin) {
+		if user != nil && !user.HasRole(auth.RoleAdmin) && !user.HasRole(auth.RoleSupport) {
 			qb = qb.Where("job.user = ?", user.Username)
 		}
 
@@ -321,7 +321,7 @@ func (r *JobRepository) FindJobOrUser(ctx context.Context, searchterm string) (j
 		}
 	}
 
-	if user == nil || user.HasRole(auth.RoleAdmin) {
+	if user == nil || user.HasRole(auth.RoleAdmin) || user.HasRole(auth.RoleSupport) {
 		err := sq.Select("job.user").Distinct().From("job").
 			Where("job.user = ?", searchterm).
 			RunWith(r.stmtCache).QueryRow().Scan(&username)

--- a/internal/repository/query.go
+++ b/internal/repository/query.go
@@ -94,7 +94,7 @@ func (r *JobRepository) CountJobs(
 
 func SecurityCheck(ctx context.Context, query sq.SelectBuilder) sq.SelectBuilder {
 	user := auth.GetUser(ctx)
-	if user == nil || user.HasRole(auth.RoleAdmin) || user.HasRole(auth.RoleApi) {
+	if user == nil || user.HasRole(auth.RoleAdmin) || user.HasRole(auth.RoleApi) || user.HasRole(auth.RoleSupport) {
 		return query
 	}
 

--- a/internal/routerConfig/routes.go
+++ b/internal/routerConfig/routes.go
@@ -269,15 +269,17 @@ func SetupRoutes(router *mux.Router) {
 				title = strings.Replace(route.Title, "<ID>", id.(string), 1)
 			}
 
-			username, isAdmin := "", true
+			username, isAdmin, isSupporter := "", true, true
+			
 			if user := auth.GetUser(r.Context()); user != nil {
 				username = user.Username
 				isAdmin = user.HasRole(auth.RoleAdmin)
+				isSupporter = user.HasRole(auth.RoleSupport)
 			}
 
 			page := web.Page{
 				Title:  title,
-				User:   web.User{Username: username, IsAdmin: isAdmin},
+				User:   web.User{Username: username, IsAdmin: isAdmin, IsSupporter: isSupporter},
 				Config: conf,
 				Infos:  infos,
 			}

--- a/web/templates/config.tmpl
+++ b/web/templates/config.tmpl
@@ -38,6 +38,10 @@
                     <input type="radio" id="admin" name="role" value="admin"/>
                     <label for="admin">Admin</label>
                 </div>
+                <div>
+                    <input type="radio" id="support" name="role" value="support"/>
+                    <label for="support">Support</label>
+                </div>
             </div>
             <p>
                 <code class="form-result"></code>
@@ -131,6 +135,7 @@
                     <option selected value="">Role...</option>
                     <option value="user">User</option>
                     <option value="admin">Admin</option>
+                    <option value="support">Support</option>
                     <option value="api">API</option>
                 </select>
                 <button class="btn btn-outline-secondary" type="button" id="add-role-button">Button</button>

--- a/web/web.go
+++ b/web/web.go
@@ -55,6 +55,7 @@ func init() {
 type User struct {
 	Username string // Username of the currently logged in user
 	IsAdmin  bool
+	IsSupporter bool
 }
 
 type Page struct {


### PR DESCRIPTION
This pull request addresses issue #40. In daily user support, there are occasionally cases where it is helpful to be able to read the recorded metrics of a job. Until now, this was only possible if the supporter in question had admin rights. However, this would also allow him to read out authentication characteristics of another user. 
The new role "Support" gives a user the possibility to see all jobs without giving him admin rights. 