### PR TITLE
fix adding tag with disabled archive

### DIFF
--- a/cmd/cc-backend/main.go
+++ b/cmd/cc-backend/main.go
@@ -175,7 +175,7 @@ func main() {
 		log.Fatal("arguments --add-user and --del-user can only be used if authentication is enabled")
 	}
 
-	if err := archive.Init(config.Keys.Archive); err != nil {
+	if err := archive.Init(config.Keys.Archive, config.Keys.DisableArchive); err != nil {
 		log.Fatal(err)
 	}
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -32,8 +32,10 @@ type ArchiveBackend interface {
 
 var cache *lrucache.Cache = lrucache.New(128 * 1024 * 1024)
 var ar ArchiveBackend
+var useArchive bool
 
-func Init(rawConfig json.RawMessage) error {
+func Init(rawConfig json.RawMessage, disableArchive bool) error {
+	useArchive = !disableArchive
 	var kind struct {
 		Kind string `json:"kind"`
 	}
@@ -96,7 +98,7 @@ func GetStatistics(job *schema.Job) (map[string]schema.JobStatistics, error) {
 // in that JSON file. If the job is not archived, nothing is done.
 func UpdateTags(job *schema.Job, tags []*schema.Tag) error {
 
-	if job.State == schema.JobStateRunning {
+	if job.State == schema.JobStateRunning || !useArchive {
 		return nil
 	}
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -284,7 +284,7 @@ func setup(t *testing.T) *api.RestApi {
 	repository.Connect("sqlite3", dbfilepath)
 	db := repository.GetConnection()
 
-	if err := archive.Init(json.RawMessage(archiveCfg)); err != nil {
+	if err := archive.Init(json.RawMessage(archiveCfg), config.Keys.DisableArchive); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
Hi,
I had an error while creating new jobs via the REST API.
```
Error while inserting job: open var/job-archive/levante/2546/857/1667913761/meta.json: no such file or directory
```

The issue seems to be updating of tags when the config 'disable-archive' is set to true.
I made the archive aware of the disabled status, allowing to insert jobs with 'completed' state and flags in combination with disabled archiving.


