### PR TITLE
Preserve job state in stopJob and secure startJob by Mutex

### DIFF
--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -57,6 +57,7 @@ type RestApi struct {
 	Authentication    *auth.Authentication
 	MachineStateDir   string
 	OngoingArchivings sync.WaitGroup
+	RepositoryMutex   sync.Mutex
 }
 
 func (api *RestApi) MountRoutes(r *mux.Router) {
@@ -362,6 +363,11 @@ func (api *RestApi) startJob(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// aquire lock to avoid race condition between API calls
+	var unlockOnce sync.Once
+	api.RepositoryMutex.Lock()
+	defer unlockOnce.Do(api.RepositoryMutex.Unlock)
+
 	// Check if combination of (job_id, cluster_id, start_time) already exists:
 	jobs, err := api.JobRepository.FindAll(&req.JobID, &req.Cluster, nil)
 	if err != nil && err != sql.ErrNoRows {
@@ -381,6 +387,8 @@ func (api *RestApi) startJob(rw http.ResponseWriter, r *http.Request) {
 		handleError(fmt.Errorf("insert into database failed: %w", err), http.StatusInternalServerError, rw)
 		return
 	}
+	// unlock here, adding Tags can be async
+	unlockOnce.Do(api.RepositoryMutex.Unlock)
 
 	for _, tag := range req.Tags {
 		if _, err := api.JobRepository.AddTagOrCreate(id, tag.Type, tag.Name); err != nil {

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -517,7 +517,7 @@ func (api *RestApi) checkAndHandleStopJob(rw http.ResponseWriter, job *schema.Jo
 	if req.State != "" && !req.State.Valid() {
 		handleError(fmt.Errorf("invalid job state: %#v", req.State), http.StatusBadRequest, rw)
 		return
-	} else {
+	} else if req.State == "" {
 		req.State = schema.JobStateCompleted
 	}
 

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -566,8 +566,8 @@ func subtestLetJobFail(t *testing.T, restapi *api.RestApi, r *mux.Router) {
 			t.Fatal(err)
 		}
 
-		if job.State != schema.JobStateCompleted {
-			t.Fatal("expected job to be completed")
+		if job.State != schema.JobStateFailed {
+			t.Fatal("expected job to be failed")
 		}
 	})
 	if !ok {


### PR DESCRIPTION
Hi,

I would like to propose fixes for #68 and #46.
The race condition mentioned in #46 should be avoided by synchronizing the findall call to the job-repo.
The job state is no longer overwritten and just defaults to 'completed' if not given by the user.

Let me know what you think,
Cheers,
