### PR TITLE
archive jobs in single worker thread

### DIFF
--- a/cmd/cc-backend/main.go
+++ b/cmd/cc-backend/main.go
@@ -416,7 +416,7 @@ func main() {
 		server.Shutdown(context.Background())
 
 		// Then, wait for any async archivings still pending...
-		api.OngoingArchivings.Wait()
+		api.JobRepository.WaitForArchiving()
 	}()
 
 	if config.Keys.StopJobsExceedingWalltime > 0 {

--- a/internal/repository/job.go
+++ b/internal/repository/job.go
@@ -411,7 +411,6 @@ func (r *JobRepository) TriggerArchiving(job *schema.Job){
 // Wait for background thread to finish pending archiving operations
 func (r *JobRepository) WaitForArchiving(){
 	// close channel and wait for worker to process remaining jobs
-	close(r.archiveChannel)
 	r.archivePending.Wait()
 }
 

--- a/internal/repository/job.go
+++ b/internal/repository/job.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/ClusterCockpit/cc-backend/internal/auth"
 	"github.com/ClusterCockpit/cc-backend/internal/graph/model"
+	"github.com/ClusterCockpit/cc-backend/internal/metricdata"
 	"github.com/ClusterCockpit/cc-backend/pkg/log"
 	"github.com/ClusterCockpit/cc-backend/pkg/lrucache"
 	"github.com/ClusterCockpit/cc-backend/pkg/schema"
@@ -33,6 +34,9 @@ type JobRepository struct {
 
 	stmtCache *sq.StmtCache
 	cache     *lrucache.Cache
+
+	archiveChannel chan *schema.Job
+	archivePending sync.WaitGroup
 }
 
 func GetJobRepository() *JobRepository {
@@ -43,7 +47,10 @@ func GetJobRepository() *JobRepository {
 			DB:        db.DB,
 			stmtCache: sq.NewStmtCache(db.DB),
 			cache:     lrucache.New(1024 * 1024),
+			archiveChannel: make(chan *schema.Job, 128),
 		}
+		// start archiving worker
+		go jobRepoInstance.archivingWorker()
 	})
 
 	return jobRepoInstance
@@ -326,7 +333,7 @@ func (r *JobRepository) UpdateMonitoringStatus(job int64, monitoringStatus int32
 }
 
 // Stop updates the job with the database id jobId using the provided arguments.
-func (r *JobRepository) Archive(
+func (r *JobRepository) MarkArchived(
 	jobId int64,
 	monitoringStatus int32,
 	metricStats map[string]schema.JobStatistics) error {
@@ -356,6 +363,56 @@ func (r *JobRepository) Archive(
 		return err
 	}
 	return nil
+}
+
+// Archiving worker thread
+func (r *JobRepository) archivingWorker(){
+	for {
+		select {
+		case job, ok := <- r.archiveChannel:
+			if !ok {
+				break
+			}
+			// not using meta data, called to load JobMeta into Cache?
+			// will fail if job meta not in repository
+			if _, err := r.FetchMetadata(job); err != nil {
+				log.Errorf("archiving job (dbid: %d) failed: %s", job.ID, err.Error())
+				r.UpdateMonitoringStatus(job.ID, schema.MonitoringStatusArchivingFailed)
+				continue
+			}
+
+			// metricdata.ArchiveJob will fetch all the data from a MetricDataRepository and push into configured archive backend
+			// TODO: Maybe use context with cancel/timeout here
+			jobMeta, err := metricdata.ArchiveJob(job, context.Background())
+			if err != nil {
+				log.Errorf("archiving job (dbid: %d) failed: %s", job.ID, err.Error())
+				r.UpdateMonitoringStatus(job.ID, schema.MonitoringStatusArchivingFailed)
+				continue
+			}
+
+			// Update the jobs database entry one last time:
+			if err := r.MarkArchived(job.ID, schema.MonitoringStatusArchivingSuccessful, jobMeta.Statistics); err != nil {
+				log.Errorf("archiving job (dbid: %d) failed: %s", job.ID, err.Error())
+				continue
+			}
+
+			log.Printf("archiving job (dbid: %d) successful", job.ID)
+			r.archivePending.Done()
+		}
+	}
+}
+
+// Trigger async archiving
+func (r *JobRepository) TriggerArchiving(job *schema.Job){
+	r.archivePending.Add(1)
+	r.archiveChannel <- job
+}
+
+// Wait for background thread to finish pending archiving operations
+func (r *JobRepository) WaitForArchiving(){
+	// close channel and wait for worker to process remaining jobs
+	close(r.archiveChannel)
+	r.archivePending.Wait()
 }
 
 var ErrNotFound = errors.New("no such job or user")

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -441,7 +441,7 @@ func TestRestApi(t *testing.T) {
 			t.Fatal(response.Status, recorder.Body.String())
 		}
 
-		restapi.OngoingArchivings.Wait()
+		restapi.JobRepository.WaitForArchiving()
 		job, err := restapi.Resolver.Query().Job(context.Background(), strconv.Itoa(int(dbid)))
 		if err != nil {
 			t.Fatal(err)
@@ -559,7 +559,7 @@ func subtestLetJobFail(t *testing.T, restapi *api.RestApi, r *mux.Router) {
 			t.Fatal(response.Status, recorder.Body.String())
 		}
 
-		restapi.OngoingArchivings.Wait()
+		restapi.JobRepository.WaitForArchiving()
 		jobid, cluster := int64(12345), "testcluster"
 		job, err := restapi.JobRepository.Find(&jobid, &cluster, nil)
 		if err != nil {


### PR DESCRIPTION
Hi,

I would like to propose a change to the job-archiving mechanism. So far the API is starting a worker thread for each stop_job request. 
We observed two potential issues with that: If you push jobs very fast, you can run either into open file limits of the OS (meta.json and data.json for each job) or even earlier run into max parallel connections of a metricdata database.
This might not apply to cc_metric_store, but for prometheus and influx databases.

I didn't change the order of operations, but job's are pushed into a channel and archived by a worker thread in the job repository.
From my understanding this also moves job-repo functionality out of the api code.
The API calls will block, once the channel (size 128) is full, which is a good rate limiting mechanism I think.

There's one call to `FetchMetadata` (l 378 in job.go) that I don't understand, I kept it for now, but the return value is never used.

If you consider this PR, please review it carefully, I'm happy to further discuss the changes.

Cheers,
Pay