### PR TITLE
Add node name and sub-cluster to JobInfo.

### DIFF
--- a/web/frontend/src/joblist/JobInfo.svelte
+++ b/web/frontend/src/joblist/JobInfo.svelte
@@ -60,7 +60,12 @@
     </p>
 
     <p>
-        {job.numNodes} <Icon name="pc-horizontal"/>
+        {#if job.numNodes == 1}
+            {job.resources[0].hostname}
+        {:else}
+            {job.numNodes}
+        {/if}
+        <Icon name="pc-horizontal"/>
         {#if job.exclusive != 1}
             (shared)
         {/if}
@@ -70,6 +75,8 @@
         {#if job.numHWThreads > 0}
             , {job.numHWThreads} <Icon name="cpu"/>
         {/if}
+        <br/>
+        {job.subCluster}
     </p>
 
     <p>

--- a/web/frontend/src/joblist/JobList.svelte
+++ b/web/frontend/src/joblist/JobList.svelte
@@ -33,7 +33,7 @@
         jobs(filter: $filter, order: $sorting, page: $paging) {
             items {
                 id, jobId, user, project, jobName, cluster, subCluster, startTime,
-                duration, numNodes, numHWThreads, numAcc, walltime,
+                duration, numNodes, numHWThreads, numAcc, walltime, resources { hostname },
                 SMT, exclusive, partition, arrayJobId,
                 monitoringStatus, state,
                 tags { id, type, name }


### PR DESCRIPTION
We have a rather heterogeneous cluster, so it's quite interesting where a job ran.
Also, currently, all jobs are single node ones.
Therefore, for us it's quite useful to have the hostname shown as part of the JobInfo in the list and the job view, as well as the subcluster, which is helpful to understand which hardware configuration the node had.

This e.g. looks like this:
![image](https://user-images.githubusercontent.com/5982050/218434080-c01df412-1fbc-4c48-bf82-f755c2872241.png)

I'm not sure how generally useful this is, but I still wanted to post the patch :)