### PR TITLE
121 fix filter reactivity crash

### DIFF
--- a/api/schema.graphqls
+++ b/api/schema.graphqls
@@ -10,7 +10,6 @@ type Job {
   jobId:            Int!
   user:             String!
   project:          String!
-  jobName:          String
   cluster:          String!
   subCluster:       String!
   startTime:        Time!
@@ -286,7 +285,7 @@ type HistoPoint {
 
 type JobsStatistics  {
   id:             ID!            # If `groupBy` was used, ID of the user/project/cluster
-  name:           String         # if User-Statistics: Given Name of Account (ID) Owner
+  name:           String!        # if User-Statistics: Given Name of Account (ID) Owner
   totalJobs:      Int!           # Number of jobs that matched
   shortJobs:      Int!           # Number of jobs with a duration of less than 2 minutes
   totalWalltime:  Int!           # Sum of the duration of all matched jobs in hours

--- a/internal/graph/model/models_gen.go
+++ b/internal/graph/model/models_gen.go
@@ -88,7 +88,7 @@ type JobResultList struct {
 
 type JobsStatistics struct {
 	ID             string        `json:"id"`
-	Name           *string       `json:"name"`
+	Name           string        `json:"name"`
 	TotalJobs      int           `json:"totalJobs"`
 	ShortJobs      int           `json:"shortJobs"`
 	TotalWalltime  int           `json:"totalWalltime"`

--- a/internal/graph/schema.resolvers.go
+++ b/internal/graph/schema.resolvers.go
@@ -26,11 +26,6 @@ func (r *clusterResolver) Partitions(ctx context.Context, obj *schema.Cluster) (
 	return r.Repo.Partitions(obj.Name)
 }
 
-// JobName is the resolver for the jobName field.
-func (r *jobResolver) JobName(ctx context.Context, obj *schema.Job) (*string, error) {
-	return r.Repo.FetchJobName(obj)
-}
-
 // Tags is the resolver for the tags field.
 func (r *jobResolver) Tags(ctx context.Context, obj *schema.Job) ([]*schema.Tag, error) {
 	return r.Repo.GetTags(&obj.ID)
@@ -38,7 +33,6 @@ func (r *jobResolver) Tags(ctx context.Context, obj *schema.Job) ([]*schema.Tag,
 
 // ConcurrentJobs is the resolver for the concurrentJobs field.
 func (r *jobResolver) ConcurrentJobs(ctx context.Context, obj *schema.Job) (*model.JobLinkResultList, error) {
-
 	exc := int(obj.Exclusive)
 	if exc != 1 {
 		filter := []*model.JobFilter{}

--- a/web/frontend/src/Jobs.root.svelte
+++ b/web/frontend/src/Jobs.root.svelte
@@ -17,7 +17,7 @@
     export let authlevel
     export let roles
 
-    let filters = []
+    let filterComponent; // see why here: https://stackoverflow.com/questions/58287729/how-can-i-export-a-function-from-a-svelte-component-that-changes-a-value-in-the
     let jobList, matchedJobs = null
     let sorting = { field: 'startTime', order: 'DESC' }, isSortingOpen = false, isMetricsSelectionOpen = false
     let metrics = filterPresets.cluster
@@ -25,12 +25,10 @@
         : ccconfig.plot_list_selectedMetrics
     let selectedCluster = filterPresets?.cluster ? filterPresets.cluster : null
     
-    $: selectedCluster = filters[0]?.cluster ? filters[0].cluster.eq : null 
-
     // The filterPresets are handled by the Filters component,
     // so we need to wait for it to be ready before we can start a query.
     // This is also why JobList component starts out with a paused query.
-    onMount(() => filters.update())
+    onMount(() => filterComponent.update())
 </script>
 
 <Row>
@@ -61,15 +59,16 @@
     <Col xs="auto">
         <Filters
             filterPresets={filterPresets}
-            bind:this={filters}
+            bind:this={filterComponent}
             on:update={({ detail }) => {
-                filters = detail.filters
-                jobList.update(detail.filters)}
+                selectedCluster = detail.filters[0]?.cluster ? detail.filters[0].cluster.eq : null 
+                jobList.update(detail.filters)
+            }
             } />
     </Col>
 
     <Col xs="3" style="margin-left: auto;">
-        <UserOrProject bind:authlevel={authlevel} bind:roles={roles} on:update={({ detail }) => filters.update(detail)}/>
+        <UserOrProject bind:authlevel={authlevel} bind:roles={roles} on:update={({ detail }) => filterComponent.update(detail)}/>
     </Col>
     <Col xs="2">
         <Refresher on:reload={() => jobList.refresh()} />

--- a/web/frontend/src/List.root.svelte
+++ b/web/frontend/src/List.root.svelte
@@ -29,12 +29,17 @@
         "Invalid list type provided!"
     );
 
+    let filterComponent; // see why here: https://stackoverflow.com/questions/58287729/how-can-i-export-a-function-from-a-svelte-component-that-changes-a-value-in-the
+    let jobFilters = [];
+    let nameFilter = "";
+    let sorting = { field: "totalJobs", direction: "down" };
+
     const client = getContextClient();
     $: stats = queryStore({
         client: client,
         query: gql`
-            query($filters: [JobFilter!]!) {
-            rows: jobsStatistics(filter: $filters, groupBy: ${type}) {
+            query($jobFilters: [JobFilter!]!) {
+            rows: jobsStatistics(filter: $jobFilters, groupBy: ${type}) {
                 id
                 name
                 totalJobs
@@ -42,12 +47,8 @@
                 totalCoreHours
             }
         }`,
-        variables: { filters }
+        variables: { jobFilters }
     });
-
-    let filters;
-    let nameFilter = "";
-    let sorting = { field: "totalJobs", direction: "down" };
 
     function changeSorting(event, field) {
         let target = event.target;
@@ -73,7 +74,7 @@
         return stats.filter((u) => u.id.includes(nameFilter)).sort(cmp);
     }
 
-    onMount(() => filters.update());
+    onMount(() => filterComponent.update());
 </script>
 
 <Row>
@@ -93,12 +94,12 @@
     </Col>
     <Col xs="auto">
         <Filters
-            bind:this={filters}
+            bind:this={filterComponent}
             {filterPresets}
             startTimeQuickSelect={true}
             menuText="Only {type.toLowerCase()}s with jobs that match the filters will show up"
             on:update={({ detail }) => {
-                filters = detail.filters;
+                jobFilters = detail.filters;
             }}
         />
     </Col>

--- a/web/frontend/src/joblist/JobList.svelte
+++ b/web/frontend/src/joblist/JobList.svelte
@@ -47,7 +47,6 @@
                     jobId
                     user
                     project
-                    jobName
                     cluster
                     subCluster
                     startTime


### PR DESCRIPTION
Fatal crash in cc-backend verly likely caused by parallel access of metaData cache during handling of metaData and jobName fields.

The latter was unused and is non-required, as every handling of jobNames is done by accessingthem via metaData object in frontend, oh handling metaData as a whole in backend (e.g. jobName searchbar query)

Additional changes:
* Correct implementation of filter-/component (-functions) in svelte frontend
* Switch `name` field in gql scheme for JobStatistics to required, returns string