### PR TITLE
lower log level for frequent messages

### DIFF
--- a/cmd/cc-backend/main.go
+++ b/cmd/cc-backend/main.go
@@ -338,7 +338,7 @@ func main() {
 		handlers.AllowedOrigins([]string{"*"})))
 	handler := handlers.CustomLoggingHandler(io.Discard, r, func(_ io.Writer, params handlers.LogFormatterParams) {
 		if strings.HasPrefix(params.Request.RequestURI, "/api/") {
-			log.Infof("%s %s (%d, %.02fkb, %dms)",
+			log.Debugf("%s %s (%d, %.02fkb, %dms)",
 				params.Request.Method, params.URL.RequestURI(),
 				params.StatusCode, float32(params.Size)/1024,
 				time.Since(params.TimeStamp).Milliseconds())

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -523,7 +523,7 @@ func (api *RestApi) startJob(rw http.ResponseWriter, r *http.Request) {
 	} else if err == nil {
 		for _, job := range jobs {
 			if (req.StartTime - job.StartTimeUnix) < 86400 {
-				handleError(fmt.Errorf("a job with that jobId, cluster and startTime already exists: dbid: %d", job.ID), http.StatusUnprocessableEntity, rw)
+				handleError(fmt.Errorf("a job with that jobId, cluster and startTime already exists: dbid: %d, jobid: %d", job.ID, job.JobID), http.StatusUnprocessableEntity, rw)
 				return
 			}
 		}

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -364,7 +364,7 @@ func (auth *Authentication) Login(
 			return
 		}
 
-		log.Warn("login failed: no authenticator applied")
+		log.Debugf("login failed: no authenticator applied")
 		onfailure(rw, r, err)
 	})
 }
@@ -380,7 +380,7 @@ func (auth *Authentication) Auth(
 		for _, authenticator := range auth.authenticators {
 			user, err := authenticator.Auth(rw, r)
 			if err != nil {
-				log.Warnf("authentication failed: %s", err.Error())
+				log.Infof("authentication failed: %s", err.Error())
 				http.Error(rw, err.Error(), http.StatusUnauthorized)
 				return
 			}
@@ -393,7 +393,7 @@ func (auth *Authentication) Auth(
 			return
 		}
 
-		log.Warnf("authentication failed: %s", "no authenticator applied")
+		log.Debugf("authentication failed: %s", "no authenticator applied")
 		// http.Error(rw, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 		onfailure(rw, r, errors.New("unauthorized (login first or use a token)"))
 	})

--- a/internal/repository/hooks.go
+++ b/internal/repository/hooks.go
@@ -16,13 +16,13 @@ type Hooks struct{}
 
 // Before hook will print the query with it's args and return the context with the timestamp
 func (h *Hooks) Before(ctx context.Context, query string, args ...interface{}) (context.Context, error) {
-	log.Infof("SQL query %s %q", query, args)
+	log.Debugf("SQL query %s %q", query, args)
 	return context.WithValue(ctx, "begin", time.Now()), nil
 }
 
 // After hook will get the timestamp registered on the Before hook and print the elapsed time
 func (h *Hooks) After(ctx context.Context, query string, args ...interface{}) (context.Context, error) {
 	begin := ctx.Value("begin").(time.Time)
-	log.Infof("Took: %s\n", time.Since(begin))
+	log.Debugf("Took: %s\n", time.Since(begin))
 	return ctx, nil
 }

--- a/internal/repository/query.go
+++ b/internal/repository/query.go
@@ -211,7 +211,7 @@ func SecurityCheck(ctx context.Context, query sq.SelectBuilder) (sq.SelectBuilde
 		if len(user.Projects) != 0 {
 			return query.Where(sq.Or{sq.Eq{"job.project": user.Projects}, sq.Eq{"job.user": user.Username}}), nil
 		} else {
-			log.Infof("Manager-User '%s' has no defined projects to lookup! Query only personal jobs ...", user.Username)
+			log.Debugf("Manager-User '%s' has no defined projects to lookup! Query only personal jobs ...", user.Username)
 			return query.Where("job.user = ?", user.Username), nil
 		}
 	} else if user.HasRole(auth.RoleUser) { // User : Only personal jobs

--- a/internal/repository/stats.go
+++ b/internal/repository/stats.go
@@ -171,7 +171,7 @@ func (r *JobRepository) JobsStatsGrouped(
 		}
 	}
 
-	log.Infof("Timer JobsStatsGrouped %s", time.Since(start))
+	log.Debugf("Timer JobsStatsGrouped %s", time.Since(start))
 	return stats, nil
 }
 
@@ -212,7 +212,7 @@ func (r *JobRepository) JobsStats(
 				TotalAccHours:  totalAccHours})
 	}
 
-	log.Infof("Timer JobStats %s", time.Since(start))
+	log.Debugf("Timer JobStats %s", time.Since(start))
 	return stats, nil
 }
 
@@ -251,7 +251,7 @@ func (r *JobRepository) JobCountGrouped(
 		}
 	}
 
-	log.Infof("Timer JobCountGrouped %s", time.Since(start))
+	log.Debugf("Timer JobCountGrouped %s", time.Since(start))
 	return stats, nil
 }
 
@@ -300,7 +300,7 @@ func (r *JobRepository) AddJobCountGrouped(
 		}
 	}
 
-	log.Infof("Timer AddJobCountGrouped %s", time.Since(start))
+	log.Debugf("Timer AddJobCountGrouped %s", time.Since(start))
 	return stats, nil
 }
 
@@ -343,7 +343,7 @@ func (r *JobRepository) AddJobCount(
 		}
 	}
 
-	log.Infof("Timer JobJobCount %s", time.Since(start))
+	log.Debugf("Timer JobJobCount %s", time.Since(start))
 	return stats, nil
 }
 
@@ -368,7 +368,7 @@ func (r *JobRepository) AddHistograms(
 		return nil, err
 	}
 
-	log.Infof("Timer AddHistograms %s", time.Since(start))
+	log.Debugf("Timer AddHistograms %s", time.Since(start))
 	return stat, nil
 }
 
@@ -406,6 +406,6 @@ func (r *JobRepository) jobsStatisticsHistogram(
 
 		points = append(points, &point)
 	}
-	log.Infof("Timer jobsStatisticsHistogram %s", time.Since(start))
+	log.Debugf("Timer jobsStatisticsHistogram %s", time.Since(start))
 	return points, nil
 }

--- a/web/web.go
+++ b/web/web.go
@@ -106,7 +106,7 @@ func RenderTemplate(rw http.ResponseWriter, r *http.Request, file string, page *
 		}
 	}
 
-	log.Infof("Page config : %v\n", page.Config)
+	log.Debugf("Page config : %v\n", page.Config)
 	if err := t.Execute(rw, page); err != nil {
 		log.Errorf("Template error: %s", err.Error())
 	}


### PR DESCRIPTION
Hi,
I would like to propose lower log-levels for timers and some of the very frequent log messages, I think they belong into debug and quickly fill a log if you run a production instance on 'info' level.

Cheers,
Pay