### PR TITLE
138 show core accelerator scope statstable

### DIFF
--- a/web/frontend/src/Job.root.svelte
+++ b/web/frontend/src/Job.root.svelte
@@ -34,6 +34,7 @@
     export let roles;
 
     const accMetrics = ['acc_utilization', 'acc_mem_used', 'acc_power', 'nv_mem_util', 'nv_sm_clock', 'nv_temp'];
+    let accNodeOnly
 
     const { query: initq } = init(`
         job(id: "${dbid}") {
@@ -78,7 +79,7 @@
         ]);
 
         // Select default Scopes to load: Check before if accelerator metrics are not on accelerator scope by default
-        const accNodeOnly = [...toFetch].some(function(m) {
+        accNodeOnly = [...toFetch].some(function(m) {
             if (accMetrics.includes(m)) {
                 const mc = metrics(job.cluster, m)
                 return mc.scope !== 'accelerator'
@@ -398,6 +399,7 @@
                                 job={$initq.data.job}
                                 jobMetrics={$jobMetrics.data.jobMetrics}
                                 accMetrics={accMetrics}
+                                accNodeOnly={accNodeOnly}
                             />
                         {/key}
                     {/if}

--- a/web/frontend/src/Job.root.svelte
+++ b/web/frontend/src/Job.root.svelte
@@ -33,6 +33,8 @@
     export let authlevel;
     export let roles;
 
+    const accMetrics = ['acc_utilization', 'acc_mem_used', 'acc_power', 'nv_mem_util', 'nv_sm_clock', 'nv_temp'];
+
     const { query: initq } = init(`
         job(id: "${dbid}") {
             id, jobId, user, project, cluster, startTime,
@@ -76,7 +78,6 @@
         ]);
 
         // Select default Scopes to load: Check before if accelerator metrics are not on accelerator scope by default
-        const accMetrics = ['acc_utilization', 'acc_mem_used', 'acc_power', 'nv_mem_util', 'nv_sm_clock', 'nv_temp'] 
         const accNodeOnly = [...toFetch].some(function(m) {
             if (accMetrics.includes(m)) {
                 const mc = metrics(job.cluster, m)
@@ -396,6 +397,7 @@
                                 bind:this={statsTable}
                                 job={$initq.data.job}
                                 jobMetrics={$jobMetrics.data.jobMetrics}
+                                accMetrics={accMetrics}
                             />
                         {/key}
                     {/if}

--- a/web/frontend/src/StatsTable.svelte
+++ b/web/frontend/src/StatsTable.svelte
@@ -8,6 +8,7 @@
     export let job
     export let jobMetrics
     export let accMetrics
+    export let accNodeOnly
 
     const allMetrics = [...new Set(jobMetrics.map(m => m.name))].sort(),
           scopesForMetric = (metric) => jobMetrics
@@ -20,11 +21,19 @@
         isMetricSelectionOpen = false,
         selectedMetrics = getContext('cc-config')[`job_view_nodestats_selectedMetrics:${job.cluster}`]
             || getContext('cc-config')['job_view_nodestats_selectedMetrics']
-
+            
     for (let metric of allMetrics) {
-        selectedScopes[metric] = (job.exclusive != 1 || job.numNodes == 1) ? 
-            (job.numAccs != 0 && accMetrics.includes(metric)) ? 'accelerator' : 'core' 
-            : maxScope(scopesForMetric(metric))
+        // Not Exclusive or Single Node: Get maxScope()
+        // No Accelerators in Job and not Acc-Metric: Use 'core'
+        // Accelerator Metric available on accelerator scope: Use 'accelerator'
+        // Accelerator Metric only on node scope: Fallback to 'node'
+        selectedScopes[metric] = (job.exclusive != 1 || job.numNodes == 1) ?
+                                   (job.numAccs != 0 && accMetrics.includes(metric)) ?
+                                     accNodeOnly ?
+                                       'node'
+                                     : 'accelerator' 
+                                   : 'core'
+                                 : maxScope(scopesForMetric(metric))
         sorting[metric] = {
             min: { dir: 'up', active: false },
             avg: { dir: 'up', active: false },

--- a/web/frontend/src/StatsTable.svelte
+++ b/web/frontend/src/StatsTable.svelte
@@ -7,6 +7,7 @@
 
     export let job
     export let jobMetrics
+    export let accMetrics
 
     const allMetrics = [...new Set(jobMetrics.map(m => m.name))].sort(),
           scopesForMetric = (metric) => jobMetrics
@@ -21,7 +22,9 @@
             || getContext('cc-config')['job_view_nodestats_selectedMetrics']
 
     for (let metric of allMetrics) {
-        selectedScopes[metric] = maxScope(scopesForMetric(metric))
+        selectedScopes[metric] = (job.exclusive != 1 || job.numNodes == 1) ? 
+            (job.numAccs != 0 && accMetrics.includes(metric)) ? 'accelerator' : 'core' 
+            : maxScope(scopesForMetric(metric))
         sorting[metric] = {
             min: { dir: 'up', active: false },
             avg: { dir: 'up', active: false },

--- a/web/frontend/src/StatsTableEntry.svelte
+++ b/web/frontend/src/StatsTableEntry.svelte
@@ -1,17 +1,49 @@
 <script>
+    import { Icon } from 'sveltestrap'
+    
     export let host
     export let metric
     export let scope
     export let jobMetrics
 
-    function compareIds(a, b) {
+    function compareNumbers(a, b) {
         return a.id - b.id;
+    }
+
+    function sortByField(field) {
+        let s = sorting[field]
+        if (s.active) {
+            s.dir = s.dir == 'up' ? 'down' : 'up'
+        } else {
+            for (let field in sorting)
+                sorting[field].active = false
+            s.active = true
+        }
+
+        sorting = {...sorting}
+        series = series.sort((a, b) => {
+            if (a == null || b == null)
+                return -1
+
+            if (field === 'id') {
+                return s.dir != 'up' ? a[field] - b[field] : b[field] - a[field]
+            } else {
+                return s.dir != 'up' ? a.statistics[field] - b.statistics[field] : b.statistics[field] - a.statistics[field]
+            }
+        })    
+    }
+
+    let sorting = {
+            id:  { dir: 'down', active: true },
+            min: { dir: 'up', active: false },
+            avg: { dir: 'up', active: false },
+            max: { dir: 'up', active: false },
     }
 
     $: series = jobMetrics
         .find(jm => jm.name == metric && jm.scope == scope)
         ?.metric.series.filter(s => s.hostname == host && s.statistics != null)
-        ?.sort(compareIds)
+        ?.sort(compareNumbers)
 </script>
 
 {#if series == null || series.length == 0}
@@ -29,6 +61,14 @@
 {:else}
     <td colspan="4">
         <table style="width: 100%;">
+            <tr>
+                {#each ['id', 'min', 'avg', 'max'] as field}
+                    <th on:click={() => sortByField(field)}>
+                        Sort
+                        <Icon name="caret-{sorting[field].dir}{sorting[field].active ? '-fill' : ''}" />
+                    </th>
+                {/each}
+            </tr>
             {#each series as s, i}
                 <tr>
                     <th>{s.id ?? i}</th>

--- a/web/frontend/src/StatsTableEntry.svelte
+++ b/web/frontend/src/StatsTableEntry.svelte
@@ -4,9 +4,14 @@
     export let scope
     export let jobMetrics
 
+    function compareIds(a, b) {
+        return a.id - b.id;
+    }
+
     $: series = jobMetrics
         .find(jm => jm.name == metric && jm.scope == scope)
         ?.metric.series.filter(s => s.hostname == host && s.statistics != null)
+        ?.sort(compareIds)
 </script>
 
 {#if series == null || series.length == 0}


### PR DESCRIPTION
Stats Table in Job View loads granular metrics if

* Job not Exclusive or not single node job -> Get maxScope() automatic
* No Accelerators in Job *and* not Acc-Metric -> Use 'core' (== hwtread) by default
* Accelerator Metric available with config'd accelerator scope -> Use 'accelerator' by default
 * Accelerator Metric only on node scope -> Fallback and use 'node'