### PR TITLE
Prometheus backend: omit metrics with empty series

### DIFF
--- a/internal/metricdata/prometheus.go
+++ b/internal/metricdata/prometheus.go
@@ -326,7 +326,6 @@ func (pdb *PrometheusDataRepository) LoadData(
 					Timestep: metricConfig.Timestep,
 					Series:   make([]schema.Series, 0),
 				}
-				jobData[metric][scope] = jobMetric
 			}
 			step := int64(metricConfig.Timestep)
 			steps := int64(to.Sub(from).Seconds()) / step
@@ -334,6 +333,10 @@ func (pdb *PrometheusDataRepository) LoadData(
 			for _, row := range result.(promm.Matrix) {
 				jobMetric.Series = append(jobMetric.Series,
 					pdb.RowToSeries(from, step, steps, row))
+			}
+			// only add metric if at least one host returned data
+			if !ok && len(jobMetric.Series) > 0{
+				jobData[metric][scope] = jobMetric
 			}
 			// sort by hostname to get uniform coloring
 			sort.Slice(jobMetric.Series, func(i, j int) bool {


### PR DESCRIPTION
Hi,

I would like to merge a fix in the prometheus backend. In case of missing data from all hosts of some metric, the backend would so far return a jobMetric object with a Series of length zero. This causes the frontend to crash inside MetricPlot.svelte where some checks rely on series[0].data.length

This PR only adds scope/metric data if at least one host returned values and fixes the issue.
