### PR TITLE
Ldap name config

### DIFF
--- a/configs/README.md
+++ b/configs/README.md
@@ -32,6 +32,7 @@ It is supported to set these by means of a `.env` file in the project root.
    - `search_dn`: Type string. DN for authenticating LDAP admin account with general read rights.
    - `user_bind`: Type string. Expression used to authenticate users via LDAP bind. Must contain `uid={username}`.
    - `user_filter`: Type string. Filter to extract users for syncing.
+   - `username_attr`: Type string. Attribute with full user name. Defaults to `gecos` if not provided.
    - `sync_interval`: Type string. Interval used for syncing local user table with LDAP directory. Parsed using time.ParseDuration.
    - `sync_del_old_users`: Type bool. Delete obsolete users in database.
 * `clusters`: Type array of objects

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -134,8 +134,12 @@ func (r *UserRepository) AddUser(user *schema.User) error {
 func (r *UserRepository) DelUser(username string) error {
 
 	_, err := r.DB.Exec(`DELETE FROM user WHERE user.username = ?`, username)
-	log.Errorf("Error while deleting user '%s' from DB", username)
-	return err
+	if err != nil {
+		log.Errorf("Error while deleting user '%s' from DB", username)
+		return err
+	}
+	log.Infof("deleted user '%s' from DB", username)
+	return nil
 }
 
 func (r *UserRepository) ListUsers(specialsOnly bool) ([]*schema.User, error) {

--- a/pkg/schema/config.go
+++ b/pkg/schema/config.go
@@ -15,6 +15,7 @@ type LdapConfig struct {
 	SearchDN        string `json:"search_dn"`
 	UserBind        string `json:"user_bind"`
 	UserFilter      string `json:"user_filter"`
+	UserAttr		string `json:"username_attr"`
 	SyncInterval    string `json:"sync_interval"` // Parsed using time.ParseDuration.
 	SyncDelOldUsers bool   `json:"sync_del_old_users"`
 

--- a/pkg/schema/schemas/config.schema.json
+++ b/pkg/schema/schemas/config.schema.json
@@ -180,6 +180,10 @@
                     "description": "Filter to extract users for syncing.",
                     "type": "string"
                 },
+                "username_attr": {
+                    "description": "Attribute with full username. Default: gecos",
+                    "type": "string"
+                },
                 "sync_interval": {
                     "description": "Interval used for syncing local user table with LDAP directory. Parsed using time.ParseDuration.",
                     "type": "string"


### PR DESCRIPTION
Hi,
I would like to propose a small improvement to the ldap auth module: In our LDAP, full user names are stored in the 'cn' attribute, not in 'gecos'.
I made the attribute to look for user names a config option which defaults to 'gecos' if not provided. Shouldn't break with older configs like this.

Also fixes a small bug in DelUser where the error log was printed independent of the error.

