### PR TITLE
fix: fix crashing job view if roofline metrics missing

### DIFF
--- a/web/frontend/src/Job.root.svelte
+++ b/web/frontend/src/Job.root.svelte
@@ -280,12 +280,12 @@
           .find((c) => c.name == $initq.data.job.cluster)
           .subClusters.find((sc) => sc.name == $initq.data.job.subCluster)}
         data={transformDataForRoofline(
-          $jobMetrics.data.jobMetrics.find(
+          $jobMetrics.data?.jobMetrics?.find(
             (m) => m.name == "flops_any" && m.scope == "node",
-          ).metric,
-          $jobMetrics.data.jobMetrics.find(
+          )?.metric,
+          $jobMetrics.data?.jobMetrics?.find(
             (m) => m.name == "mem_bw" && m.scope == "node",
-          ).metric,
+          )?.metric,
         )}
       />
     </Col>


### PR DESCRIPTION
Quick fix via null-safe ternary operator