### PR TITLE
Hotfix: add orderBy param to jobRepo.Find

### DIFF
--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -929,7 +929,7 @@ func (api *RestApi) stopJobByRequest(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("loading db job for stopJobByRequest... : stopJobApiRequest=%v", req)
+	// log.Printf("loading db job for stopJobByRequest... : stopJobApiRequest=%v", req)
 	job, err = api.JobRepository.Find(req.JobId, req.Cluster, req.StartTime)
 
 	if err != nil {

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -929,7 +929,7 @@ func (api *RestApi) stopJobByRequest(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("loading db job from request for stopJobByRequest... : jobId=%d, cluster=%v, startTime=%d", req.JobId, req.Cluster, req.StartTime)
+	log.Printf("loading db job for stopJobByRequest... : stopJobApiRequest=%#v", req)
 	job, err = api.JobRepository.Find(req.JobId, req.Cluster, req.StartTime)
 
 	if err != nil {

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -929,6 +929,7 @@ func (api *RestApi) stopJobByRequest(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	log.Printf("loading db job from request for stopJobByRequest... : jobId=%d, cluster=%s, startTime=%d", *req.JobId, *req.Cluster, *req.StartTime)
 	job, err = api.JobRepository.Find(req.JobId, req.Cluster, req.StartTime)
 
 	if err != nil {

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -929,7 +929,7 @@ func (api *RestApi) stopJobByRequest(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("loading db job for stopJobByRequest... : stopJobApiRequest=%#v", req)
+	log.Printf("loading db job for stopJobByRequest... : stopJobApiRequest=%v", req)
 	job, err = api.JobRepository.Find(req.JobId, req.Cluster, req.StartTime)
 
 	if err != nil {

--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -929,7 +929,7 @@ func (api *RestApi) stopJobByRequest(rw http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	log.Printf("loading db job from request for stopJobByRequest... : jobId=%d, cluster=%s, startTime=%d", *req.JobId, *req.Cluster, *req.StartTime)
+	log.Printf("loading db job from request for stopJobByRequest... : jobId=%d, cluster=%v, startTime=%d", req.JobId, req.Cluster, req.StartTime)
 	job, err = api.JobRepository.Find(req.JobId, req.Cluster, req.StartTime)
 
 	if err != nil {

--- a/internal/repository/job.go
+++ b/internal/repository/job.go
@@ -235,10 +235,10 @@ func (r *JobRepository) Find(
 		q = q.Where("job.start_time = ?", *startTime)
 	}
 
-	q = q.OrderBy("job.id DESC") // always use newest matching job by db id
+	q = q.OrderBy("job.id DESC") // always use newest matching job by db id if more than one match
 
-	s, args, _ := q.ToSql()
-	log.Printf("trying to find db job with query: %s | %v", s, args)
+	// s, args, _ := q.ToSql()
+	// log.Printf("trying to find db job with query: %s | %v", s, args)
 
 	log.Debugf("Timer Find %s", time.Since(start))
 	return scanJob(q.RunWith(r.stmtCache).QueryRow())

--- a/internal/repository/job.go
+++ b/internal/repository/job.go
@@ -235,6 +235,9 @@ func (r *JobRepository) Find(
 		q = q.Where("job.start_time = ?", *startTime)
 	}
 
+	s, _, _ := q.ToSql()
+	log.Printf("trying to find db job with query: %s", s)
+
 	log.Debugf("Timer Find %s", time.Since(start))
 	return scanJob(q.RunWith(r.stmtCache).QueryRow())
 }

--- a/internal/repository/job.go
+++ b/internal/repository/job.go
@@ -235,8 +235,10 @@ func (r *JobRepository) Find(
 		q = q.Where("job.start_time = ?", *startTime)
 	}
 
-	s, _, _ := q.ToSql()
-	log.Printf("trying to find db job with query: %s", s)
+	q = q.OrderBy("job.id DESC") // always use newest matching job by db id
+
+	s, args, _ := q.ToSql()
+	log.Printf("trying to find db job with query: %s | %v", s, args)
 
 	log.Debugf("Timer Find %s", time.Since(start))
 	return scanJob(q.RunWith(r.stmtCache).QueryRow())

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -321,9 +321,10 @@ const ContextUserKey ContextKey = "user"
 func GetUserFromContext(ctx context.Context) *schema.User {
 	x := ctx.Value(ContextUserKey)
 	if x == nil {
+		log.Warnf("no user retrieved from context")
 		return nil
 	}
-
+	log.Infof("user retrieved from context: %v", x.(*schema.User))
 	return x.(*schema.User)
 }
 

--- a/internal/repository/user.go
+++ b/internal/repository/user.go
@@ -324,7 +324,7 @@ func GetUserFromContext(ctx context.Context) *schema.User {
 		log.Warnf("no user retrieved from context")
 		return nil
 	}
-	log.Infof("user retrieved from context: %v", x.(*schema.User))
+	// log.Infof("user retrieved from context: %v", x.(*schema.User))
 	return x.(*schema.User)
 }
 

--- a/internal/routerConfig/routes.go
+++ b/internal/routerConfig/routes.go
@@ -254,6 +254,9 @@ func SetupRoutes(router *mux.Router, buildInfo web.Build) {
 	for _, route := range routes {
 		route := route
 		router.HandleFunc(route.Route, func(rw http.ResponseWriter, r *http.Request) {
+
+			log.Info(">>> HELLO ROUTE HANDLER ...")
+
 			conf, err := userCfgRepo.GetUIConfig(repository.GetUserFromContext(r.Context()))
 			if err != nil {
 				http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -261,15 +264,21 @@ func SetupRoutes(router *mux.Router, buildInfo web.Build) {
 			}
 
 			title := route.Title
+			log.Infof(">>> >>> ROUTE TITLE : %s ", title)
+
 			infos := route.Setup(map[string]interface{}{}, r)
 			if id, ok := infos["id"]; ok {
 				title = strings.Replace(route.Title, "<ID>", id.(string), 1)
 			}
+			log.Infof(">>> >>> ROUTE INFOS : %v ", infos)
 
 			// Get User -> What if NIL?
 			user := repository.GetUserFromContext(r.Context())
+			log.Infof(">>> >>> ROUTE USER : %v ", *user)
+
 			// Get Roles
 			availableRoles, _ := schema.GetValidRolesMap(user)
+			log.Infof(">>> >>> ROUTE AVAILABLE ROLES : %v ", availableRoles)
 
 			page := web.Page{
 				Title:  title,
@@ -279,10 +288,12 @@ func SetupRoutes(router *mux.Router, buildInfo web.Build) {
 				Config: conf,
 				Infos:  infos,
 			}
+			log.Infof(">>> >>> ROUTE PAGE : %v ", page)
 
 			if route.Filter {
 				page.FilterPresets = buildFilterPresets(r.URL.Query())
 			}
+			log.Infof(">>> >>> ROUTE FILTER : %v ", page.FilterPresets)
 
 			web.RenderTemplate(rw, route.Template, &page)
 		})

--- a/internal/routerConfig/routes.go
+++ b/internal/routerConfig/routes.go
@@ -51,21 +51,19 @@ func setupHomeRoute(i InfoType, r *http.Request) InfoType {
 	jobRepo := repository.GetJobRepository()
 	groupBy := model.AggregateCluster
 
-	log.Infof(">>> HELLO HOME ROUTE")
-
-	startJobCount := time.Now()
+	// startJobCount := time.Now()
 	stats, err := jobRepo.JobCountGrouped(r.Context(), nil, &groupBy)
 	if err != nil {
 		log.Warnf("failed to count jobs: %s", err.Error())
 	}
-	log.Infof("Timer HOME ROUTE startJobCount: %s", time.Since(startJobCount))
+	// log.Infof("Timer HOME ROUTE startJobCount: %s", time.Since(startJobCount))
 
-	startRunningJobCount := time.Now()
+	// startRunningJobCount := time.Now()
 	stats, err = jobRepo.AddJobCountGrouped(r.Context(), nil, &groupBy, stats, "running")
 	if err != nil {
 		log.Warnf("failed to count running jobs: %s", err.Error())
 	}
-	log.Infof("Timer HOME ROUTE startRunningJobCount: %s", time.Since(startRunningJobCount))
+	// log.Infof("Timer HOME ROUTE startRunningJobCount: %s", time.Since(startRunningJobCount))
 
 	i["clusters"] = stats
 
@@ -77,8 +75,6 @@ func setupHomeRoute(i InfoType, r *http.Request) InfoType {
 			i["message"] = string(msg)
 		}
 	}
-
-	log.Infof("... BYE HOME ROUTE")
 
 	return i
 }
@@ -262,8 +258,6 @@ func SetupRoutes(router *mux.Router, buildInfo web.Build) {
 	for _, route := range routes {
 		route := route
 		router.HandleFunc(route.Route, func(rw http.ResponseWriter, r *http.Request) {
-			log.Info(">>> HELLO ROUTE HANDLER ...")
-
 			conf, err := userCfgRepo.GetUIConfig(repository.GetUserFromContext(r.Context()))
 			if err != nil {
 				http.Error(rw, err.Error(), http.StatusInternalServerError)
@@ -294,7 +288,6 @@ func SetupRoutes(router *mux.Router, buildInfo web.Build) {
 			if route.Filter {
 				page.FilterPresets = buildFilterPresets(r.URL.Query())
 			}
-			log.Infof("... ROUTE HANDLED: %s for %v", page.Title, page.User)
 
 			web.RenderTemplate(rw, route.Template, &page)
 		})


### PR DESCRIPTION
Prevents undead jobs if db job count is high and thus jobIds are overflowing/looping