### PR TITLE
Improve footprint transactions

### DIFF
--- a/internal/taskManager/updateFootprintService.go
+++ b/internal/taskManager/updateFootprintService.go
@@ -76,17 +76,18 @@ func RegisterFootprintWorker() {
 							Statistics: make(map[string]schema.JobStatistics),
 						}
 
-						for metric := range jobStats { // Metric, Hostname:Stats
+						for _, metric := range allMetrics {
 							avg, min, max := 0.0, 0.0, 0.0 // math.MaxFloat32, -math.MaxFloat32
-
-							data, ok := jobStats[metric]
+							data, ok := jobStats[metric]   // Metric:[Hostname:Stats]
 							if ok {
-								for hostname := range data {
-									hostStats, ok := data[hostname]
+								for _, res := range job.Resources {
+									hostStats, ok := data[res.Hostname]
 									if ok {
 										avg += hostStats.Avg
 										min = math.Min(min, hostStats.Min)
 										max = math.Max(max, hostStats.Max)
+									} else {
+										log.Debugf("no stats data return for host %s in job %d, metric %s", res.Hostname, job.JobID, metric)
 									}
 								}
 							} else {

--- a/internal/taskManager/updateFootprintService.go
+++ b/internal/taskManager/updateFootprintService.go
@@ -51,14 +51,14 @@ func RegisterFootprintWorker() {
 
 					repo, err := metricdata.GetMetricDataRepo(cluster.Name)
 					if err != nil {
-						log.Warnf("no metric data repository configured for '%s'", cluster.Name)
+						log.Errorf("no metric data repository configured for '%s'", cluster.Name)
 						continue
 					}
 
 					pendingStatements := []sq.UpdateBuilder{}
 
 					for _, job := range jobs {
-						log.Debugf("Try job %d", job.JobID)
+						log.Debugf("Prepare job %d", job.JobID)
 						cl++
 
 						s_job := time.Now()
@@ -116,7 +116,6 @@ func RegisterFootprintWorker() {
 						pendingStatements = append(pendingStatements, stmt)
 						log.Debugf("Job %d took %s", job.JobID, time.Since(s_job))
 					}
-					log.Debugf("Finish preparation for %d jobs: %d statements", len(jobs), len(pendingStatements))
 
 					t, err := jobRepo.TransactionInit()
 					if err != nil {
@@ -131,7 +130,7 @@ func RegisterFootprintWorker() {
 							ce++
 						} else {
 							// Args: JSON, JSON, ENERGY, JOBID
-							log.Infof("add transaction on index %d", idx)
+							log.Debugf("add transaction on index %d", idx)
 							jobRepo.TransactionAdd(t, query, args...)
 							c++
 						}

--- a/internal/taskManager/updateFootprintService.go
+++ b/internal/taskManager/updateFootprintService.go
@@ -76,19 +76,21 @@ func RegisterFootprintWorker() {
 							Statistics: make(map[string]schema.JobStatistics),
 						}
 
-						for metric, data := range jobStats { // Metric, Hostname:Stats
-							avg, min, max := 0.0, math.MaxFloat32, -math.MaxFloat32
+						for metric := range jobStats { // Metric, Hostname:Stats
+							avg, min, max := 0.0, 0.0, 0.0 // math.MaxFloat32, -math.MaxFloat32
 
-							for hostname := range data {
-								hostStats, ok := data[hostname]
-								if !ok {
-									log.Debugf("footprintWorker: NAN stats returned for job %d @ %s", job.JobID, hostname)
-								} else {
-									log.Debugf("stats returned for job %d : %#v", job.JobID, hostStats)
-									avg += hostStats.Avg
-									min = math.Min(min, hostStats.Min)
-									max = math.Max(max, hostStats.Max)
+							data, ok := jobStats[metric]
+							if ok {
+								for hostname := range data {
+									hostStats, ok := data[hostname]
+									if ok {
+										avg += hostStats.Avg
+										min = math.Min(min, hostStats.Min)
+										max = math.Max(max, hostStats.Max)
+									}
 								}
+							} else {
+								log.Debugf("no stats data return for job %d, metric %s", job.JobID, metric)
 							}
 
 							// Add values rounded to 2 digits

--- a/internal/taskManager/updateFootprintService.go
+++ b/internal/taskManager/updateFootprintService.go
@@ -55,7 +55,7 @@ func RegisterFootprintWorker() {
 						continue
 					}
 
-					pendingStatements := make([]sq.UpdateBuilder, len(jobs))
+					pendingStatements := []sq.UpdateBuilder{}
 
 					for _, job := range jobs {
 						log.Debugf("Try job %d", job.JobID)

--- a/internal/taskManager/updateFootprintService.go
+++ b/internal/taskManager/updateFootprintService.go
@@ -79,10 +79,16 @@ func RegisterFootprintWorker() {
 						for metric, data := range jobStats { // Metric, Hostname:Stats
 							avg, min, max := 0.0, math.MaxFloat32, -math.MaxFloat32
 
-							for _, hostStats := range data {
-								avg += hostStats.Avg
-								min = math.Min(min, hostStats.Min)
-								max = math.Max(max, hostStats.Max)
+							for hostname := range data {
+								hostStats, ok := data[hostname]
+								if !ok {
+									log.Debugf("footprintWorker: NAN stats returned for job %d @ %s", job.JobID, hostname)
+								} else {
+									log.Debugf("stats returned for job %d : %#v", job.JobID, hostStats)
+									avg += hostStats.Avg
+									min = math.Min(min, hostStats.Min)
+									max = math.Max(max, hostStats.Max)
+								}
 							}
 
 							// Add values rounded to 2 digits

--- a/internal/taskManager/updateFootprintService.go
+++ b/internal/taskManager/updateFootprintService.go
@@ -77,8 +77,8 @@ func RegisterFootprintWorker() {
 						}
 
 						for _, metric := range allMetrics {
-							avg, min, max := 0.0, 0.0, 0.0 // math.MaxFloat32, -math.MaxFloat32
-							data, ok := jobStats[metric]   // Metric:[Hostname:Stats]
+							avg, min, max := 0.0, 0.0, 0.0
+							data, ok := jobStats[metric] // Metric:[Hostname:Stats]
 							if ok {
 								for _, res := range job.Resources {
 									hostStats, ok := data[res.Hostname]
@@ -86,13 +86,15 @@ func RegisterFootprintWorker() {
 										avg += hostStats.Avg
 										min = math.Min(min, hostStats.Min)
 										max = math.Max(max, hostStats.Max)
-									} else {
-										log.Debugf("no stats data return for host %s in job %d, metric %s", res.Hostname, job.JobID, metric)
 									}
+									// else {
+									// 	log.Debugf("no stats data return for host %s in job %d, metric %s", res.Hostname, job.JobID, metric)
+									// }
 								}
-							} else {
-								log.Debugf("no stats data return for job %d, metric %s", job.JobID, metric)
 							}
+							// else {
+							// 	log.Debugf("no stats data return for job %d, metric %s", job.JobID, metric)
+							// }
 
 							// Add values rounded to 2 digits
 							jobMeta.Statistics[metric] = schema.JobStatistics{


### PR DESCRIPTION
* Remove non-required requested scopes 
* Use `repo.LoadStats` instead of `repo.LoadData`
* Decouple Transaction Init and Commits from Data-Loadduring statement preparation

Local Speedup, tested with Prod Data: from ~3:20m to ~9s 