### PR TITLE
fix: Update to resampler handling different resolutions

### DIFF
--- a/pkg/resampler/resampler.go
+++ b/pkg/resampler/resampler.go
@@ -9,7 +9,7 @@ import (
 )
 
 func SimpleResampler(data []schema.Float, old_frequency int64, new_frequency int64) ([]schema.Float, error) {
-	if old_frequency == 0 || new_frequency == 0 {
+	if old_frequency == 0 || new_frequency == 0 || new_frequency <= old_frequency {
 		return nil, errors.New("either old or new frequency is set to 0")
 	}
 
@@ -37,7 +37,7 @@ func SimpleResampler(data []schema.Float, old_frequency int64, new_frequency int
 // Adapted from https://github.com/haoel/downsampling/blob/master/core/lttb.go
 func LargestTriangleThreeBucket(data []schema.Float, old_frequency int, new_frequency int) ([]schema.Float, int, error) {
 
-	if old_frequency == 0 || new_frequency == 0 {
+	if old_frequency == 0 || new_frequency == 0 || new_frequency <= old_frequency {
 		return data, old_frequency, nil
 	}
 

--- a/pkg/resampler/resampler.go
+++ b/pkg/resampler/resampler.go
@@ -8,20 +8,20 @@ import (
 	"github.com/ClusterCockpit/cc-backend/pkg/schema"
 )
 
-func SimpleResampler(data []schema.Float, old_frequency int64, new_frequency int64) ([]schema.Float, error) {
+func SimpleResampler(data []schema.Float, old_frequency int64, new_frequency int64) ([]schema.Float, int64, error) {
 	if old_frequency == 0 || new_frequency == 0 || new_frequency <= old_frequency {
-		return nil, errors.New("either old or new frequency is set to 0")
+		return data, old_frequency, nil
 	}
 
 	if new_frequency%old_frequency != 0 {
-		return nil, errors.New("new sampling frequency should be multiple of the old frequency")
+		return nil, 0, errors.New("new sampling frequency should be multiple of the old frequency")
 	}
 
 	var step int = int(new_frequency / old_frequency)
 	var new_data_length = len(data) / step
 
 	if new_data_length == 0 || len(data) < 100 || new_data_length >= len(data) {
-		return data, nil
+		return data, old_frequency, nil
 	}
 
 	new_data := make([]schema.Float, new_data_length)
@@ -30,7 +30,7 @@ func SimpleResampler(data []schema.Float, old_frequency int64, new_frequency int
 		new_data[i] = data[i*step]
 	}
 
-	return new_data, nil
+	return new_data, new_frequency, nil
 }
 
 // Inspired by one of the algorithms from https://skemman.is/bitstream/1946/15343/3/SS_MSthesis.pdf


### PR DESCRIPTION
Resampler didnt handle when new resolution was lesser than native/old resolution.
Now resampler just returns old data with old resolution if ne resolution is finer/lesser than the old resolution.