### PR TITLE
fix: Fix go version in go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ClusterCockpit/cc-backend
 
-go 1.23
+go 1.23.0
 
 require (
 	github.com/99designs/gqlgen v0.17.57


### PR DESCRIPTION
If the local go version is not up to date, go was previously unable to obtain a more recent version, since the required version in go.mod is not available.