### PR TITLE
Add config for default of job_view_selectedMetrics:<cluster_name>

### DIFF
--- a/configs/default_metrics.json
+++ b/configs/default_metrics.json
@@ -1,0 +1,12 @@
+{
+  "clusters": [
+    {
+      "name": "fritz",
+      "default_metrics": "cpu_load, flops_any, core_power, lustre_open, mem_used, mem_bw, net_bytes_in"
+    },
+    {
+      "name": "alex",
+      "default_metrics": "flops_any, mem_bw, mem_used, vectorization_ratio"
+    }
+  ]
+}

--- a/internal/config/default_metrics.go
+++ b/internal/config/default_metrics.go
@@ -1,0 +1,44 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"strings"
+)
+
+type DefaultMetricsCluster struct {
+	Name           string `json:"name"`
+	DefaultMetrics string `json:"default_metrics"`
+}
+
+type DefaultMetricsConfig struct {
+	Clusters []DefaultMetricsCluster `json:"clusters"`
+}
+
+func LoadDefaultMetricsConfig() (*DefaultMetricsConfig, error) {
+	filePath := "configs/default_metrics.json"
+	if _, err := os.Stat(filePath); os.IsNotExist(err) {
+		return nil, nil
+	}
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, err
+	}
+	var cfg DefaultMetricsConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func ParseMetricsString(s string) []string {
+	parts := strings.Split(s, ",")
+	var metrics []string
+	for _, p := range parts {
+		trimmed := strings.TrimSpace(p)
+		if trimmed != "" {
+			metrics = append(metrics, trimmed)
+		}
+	}
+	return metrics
+}


### PR DESCRIPTION
This PR introduces a new mechanism to set default job-view metrics for all new users (both locally created and LDAP-imported). Instead of having every new user start with the full list of metrics—which can be overwhelming—we now load a smaller subset of default metrics from an external configuration file.

### Key Changes

  * A new JSON file is added at `configs/default_metrics.json` where you can define default metrics for each cluster. 
  * During user creation (using the existing AddUser function), the system checks for the presence of the `configs/default_metrics.json` file. For every cluster defined in the file, a new configuration entry is inserted into the database under the key `job_view_selectedMetrics:<cluster name>` with the metrics parsed by splitting the comma-separated string. The order specified in the file is respected.
  * If the `default_metrics.json` file does not exist, the default behavior is used.
  * If any metric in the configuration string is misspelled or invalid, it is simply ignored without causing any errors.
  * Regardless of the metrics specified in the JSON file, the mandatory metrics `flops_any`, `mem_used`, and `mem_bw` are always enforced.

### Discussion Points

* File location and naming:
The new file is placed at `configs/default_metrics.json`. I am open to feedback if a different location or filename is preferred.

* JSON schema:
Similarly, the structure of the JSON is open for discussion.