### PR TITLE
Fix SessionMaxAge condition to correctly apply valid values

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -88,7 +88,7 @@ func Init() {
 			authInstance.sessionStore = sessions.NewCookieStore(bytes)
 		}
 
-		if d, err := time.ParseDuration(config.Keys.SessionMaxAge); err != nil {
+		if d, err := time.ParseDuration(config.Keys.SessionMaxAge); err == nil {
 			authInstance.SessionMaxAge = d
 		}
 


### PR DESCRIPTION
Fixed an error where SessionMaxAge was only set when parsing failed (err != nil).

Now correctly applies values from the config.