### PR TITLE
use extendedLegend in nodeList for all non-idle nodes

### DIFF
--- a/web/frontend/src/systems/nodelist/NodeListRow.svelte
+++ b/web/frontend/src/systems/nodelist/NodeListRow.svelte
@@ -98,8 +98,8 @@
 
   let extendedLegendData = null;
   $: if ($nodeJobsData?.data) {
-    // Get Shared State of Node: Only Build extended Legend For Shared Nodes
-    if ($nodeJobsData.data.jobs.count >= 1 && !$nodeJobsData.data.jobs.items[0].exclusive) {
+    // Build Extended for allocated nodes [Commented: Only Build extended Legend For Shared Nodes]
+    if ($nodeJobsData.data.jobs.count >= 1) { // "&& !$nodeJobsData.data.jobs.items[0].exclusive)"
       const accSet = Array.from(new Set($nodeJobsData.data.jobs.items
         .map((i) => i.resources
           .filter((r) => r.hostname === nodeData.host)


### PR DESCRIPTION
- allows for more information on all exclusivity states, instead of missing information if exclusivity job flag is always exclusive
- changed from "use for shared nodes only"
