### PR TITLE
allow /start_job/ with 0 second duration

### DIFF
--- a/internal/api/rest.go
+++ b/internal/api/rest.go
@@ -1008,8 +1008,8 @@ func (api *RestApi) checkAndHandleStopJob(rw http.ResponseWriter, job *schema.Jo
 		return
 	}
 
-	if job == nil || job.StartTime.Unix() >= req.StopTime {
-		handleError(fmt.Errorf("jobId %d (id %d) on %s : stopTime %d must be larger than startTime %d", job.JobID, job.ID, job.Cluster, req.StopTime, job.StartTime.Unix()), http.StatusBadRequest, rw)
+	if job == nil || job.StartTime.Unix() > req.StopTime {
+		handleError(fmt.Errorf("jobId %d (id %d) on %s : stopTime %d must be larger/equal than startTime %d", job.JobID, job.ID, job.Cluster, req.StopTime, job.StartTime.Unix()), http.StatusBadRequest, rw)
 		return
 	}
 


### PR DESCRIPTION
Apparently it is possible to get this for very short jobs. Do not raise an error in this case.