### PR TITLE
fix: always return hasNextPage boolean to frontend

### DIFF
--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -28,6 +28,8 @@ For release specific notes visit the [ClusterCockpit Documentation](https://clus
 - Color Blind Mode
   - Set on a per-user basis in options
   - Applies to plot data, plot background color, statsseries colors, roofline timescale
+- Job-View metric selection is now persisted based on the jobs subcluster.
+Helpful for heterogeneous subcluster configurations.
 - Histogram Bin Select in User-View
   - Metric-Histograms: `10 Bins` now default, selectable options `20, 50, 100`
   - Job-Duration-Histogram: `48h in 1h Bins` now default, selectable options:

--- a/web/frontend/src/Job.root.svelte
+++ b/web/frontend/src/Job.root.svelte
@@ -231,7 +231,7 @@
   <Col xs={12} md={6} xl={3} class="mb-3 mb-xxl-0">
     {#if $initq.error}
       <Card body color="danger">{$initq.error.message}</Card>
-    {:else if $initq.data}
+    {:else if $initq?.data}
       <Card class="overflow-auto" style="height: 400px;">
         <TabContent> <!-- on:tab={(e) => (status = e.detail)} -->
           {#if $initq.data?.job?.metaData?.message}
@@ -305,7 +305,7 @@
 <Card class="mb-3">
   <CardBody>
     <Row class="mb-2">
-      {#if $initq.data}
+      {#if $initq?.data}
         <Col xs="auto">
             <Button outline on:click={() => (isMetricsSelectionOpen = true)} color="primary">
               Select Metrics (Selected {selectedMetrics.length} of {availableMetrics.size} available)
@@ -318,7 +318,7 @@
     {#if $jobMetrics.error}
       <Row class="mt-2">
         <Col>
-          {#if $initq.data.job.monitoringStatus == 0 || $initq.data.job.monitoringStatus == 2}
+          {#if $initq?.data && ($initq.data.job?.monitoringStatus == 0 || $initq.data.job?.monitoringStatus == 2)}
             <Card body color="warning">Not monitored or archiving failed</Card>
             <br />
           {/if}
@@ -365,7 +365,7 @@
 <!-- Statistcics Table -->
 <Row class="mb-3">
   <Col>
-    {#if $initq.data}
+    {#if $initq?.data}
       <Card>
         <TabContent>
           {#if somethingMissing}
@@ -440,7 +440,7 @@
   </Col>
 </Row>
 
-{#if $initq.data}
+{#if $initq?.data}
   <MetricSelection
     cluster={$initq.data.job.cluster}
     subCluster={$initq.data.job.subCluster}


### PR DESCRIPTION
## Issue

If backend-default `UiDefaults["job_list_usePaging"]` was set to `true`, the `hasNextPage`-Boolean was never returned to the frontend.

## Problem

It was still possible for frontend users to activate continuous scrolling, and if they did, this resulted in unresponsive job lists, i.e. no data would be added apart from the first ten jobs.

## Fix

Remove dependency on `uiDefaults` setting for `jobs` GQL Endpoint