### PR TITLE
[BUGFIX] correct wrong variable in AuthApi error logging

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -331,7 +331,7 @@ func (auth *Authentication) AuthApi(
 
 		ipErr := securedCheck(user, r)
 		if ipErr != nil {
-			log.Infof("auth api -> secured check failed: %s", err.Error())
+			log.Infof("auth api -> secured check failed: %s", ipErr.Error())
 			onfailure(rw, r, ipErr)
 			return
 		}


### PR DESCRIPTION
This PR fixes a small mistake in the `AuthApi` function (file: `internal/auth/auth.go`).

Currently, when `securedCheck` returns an error (`ipErr`), the following line tries to log the error:

```
log.Infof("auth api -> secured check failed: %s", err.Error())
```

However, the variable `err` does not exist at this point — it should be `ipErr`.  
This leads to a panic at runtime if an authorization error occurs:

```
runtime error: invalid memory address or nil pointer dereference
goroutine 4889 [running]:
runtime/debug.Stack()
github.com/gorilla/handlers.recoveryHandler.log
github.com/gorilla/handlers.recoveryHandler.ServeHTTP.func1
panic()
main.serverInit.func9.(*Authentication).AuthApi
...
```