### PR TITLE
Fix wrong memorystore nats schema

### DIFF
--- a/internal/memorystore/configSchema.go
+++ b/internal/memorystore/configSchema.go
@@ -51,39 +51,45 @@ const configSchema = `{
         },
         "nats": {
             "description": "Configuration for accepting published data through NATS.",
-            "type": "object",
-            "properties": {
-                "address": {
-                    "description": "Address of the NATS server.",
-                    "type": "string"
-                },
-                "username": {
-                    "description": "Optional: If configured with username/password method.",
-                    "type": "string"
-                },
-                "password": {
-                    "description": "Optional: If configured with username/password method.",
-                    "type": "string"
-                },
-                "creds-file-path": {
-                    "description": "Optional: If configured with Credential File method. Path to your NATS cred file.",
-                    "type": "string"
-                },
-                "subscriptions": {
-                    "description": "Array of various subscriptions. Allows to subscibe to different subjects and publishers.",
-                    "type": "object",
-                    "properties": {
-                        "subscribe-to": {
-                            "description": "Channel name",
-                            "type": "string"
-                        },
-                        "cluster-tag": {
-                            "description": "Optional: Allow lines without a cluster tag, use this as default",
-                            "type": "string"
-                        }
-                    }
-                }
-            }
+			"type": "array",
+			"items": {
+				"type": "object",
+				"properties": {
+					"address": {
+						"description": "Address of the NATS server.",
+						"type": "string"
+					},
+					"username": {
+						"description": "Optional: If configured with username/password method.",
+						"type": "string"
+					},
+					"password": {
+						"description": "Optional: If configured with username/password method.",
+						"type": "string"
+					},
+					"creds-file-path": {
+						"description": "Optional: If configured with Credential File method. Path to your NATS cred file.",
+						"type": "string"
+					},
+					"subscriptions": {
+						"description": "Array of various subscriptions. Allows to subscibe to different subjects and publishers.",
+						"type": "array",
+						"items": {
+							"type": "object",
+							"properties": {
+								"subscribe-to": {
+									"description": "Channel name",
+									"type": "string"
+								},
+								"cluster-tag": {
+									"description": "Optional: Allow lines without a cluster tag, use this as default",
+									"type": "string"
+								}
+							}
+						}
+					}
+				}
+			}
         }
     }
 }`


### PR DESCRIPTION
After the PR the nats config for the metric-store loads again. Previously the arrays where described in the schema, but not actually specified as an extra layer in the types.