### PR TITLE
return directly on error

### DIFF
--- a/internal/auth/ldap.go
+++ b/internal/auth/ldap.go
@@ -71,6 +71,7 @@ func (la *LdapAuthenticator) CanLogin(
 			l, err := la.getLdapConnection(true)
 			if err != nil {
 				cclog.Error("LDAP connection error")
+				return nil, false
 			}
 			defer l.Close()
 


### PR DESCRIPTION
when the ldap connection can not be established, the function CanLogin segfaults because it continues to use the variable.
This happened to me because of missing CA certificates, for example.